### PR TITLE
Add BoxPredicate type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - Unreleased
+### Added
+- `BoxPredicate` type that wraps a `Predicate` trait object to make it easier
+  to store and work with predicates through a program. Also implements `Debug`
+  and `Display` wrappers as a convenience.
 
 ## [0.2.0] - 2017-06-02
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,4 +78,4 @@
 
 // core `Predicate` trait
 pub mod predicate;
-pub use self::predicate::Predicate;
+pub use self::predicate::{BoxPredicate, Predicate};

--- a/src/predicate/boxed.rs
+++ b/src/predicate/boxed.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Predicate that can wrap other dynamically-called predicates in an
+//! easy-to-manage type.
+
+use std::fmt;
+
+use Predicate;
+
+/// `Predicate` that wraps another `Predicate` as a trait object, allowing
+/// sized storage of predicate types.
+pub struct BoxPredicate<T: ?Sized>(Box<Predicate<Item = T> + Send + Sync>);
+
+impl<T> fmt::Debug for BoxPredicate<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BoxPredicate").finish()
+    }
+}
+
+impl<T> fmt::Display for BoxPredicate<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BoxPredicate")
+    }
+}
+
+impl<T: ?Sized> Predicate for BoxPredicate<T> {
+    type Item = T;
+
+    fn eval(&self, variable: &Self::Item) -> bool {
+        self.0.eval(variable)
+    }
+}
+
+impl<T:? Sized> BoxPredicate<T> {
+    /// Creates a new `BoxPredicate`, a wrapper around a dynamically-dispatched
+    /// `Predicate` type with useful trait impls.
+    pub fn new<P: Predicate<Item = T>>(inner: P) -> BoxPredicate<T>
+        where P: Send + Sync + 'static
+    {
+        BoxPredicate(Box::new(inner))
+    }
+}
+
+

--- a/src/predicate/mod.rs
+++ b/src/predicate/mod.rs
@@ -22,7 +22,9 @@ pub use self::set::{contains, ContainsPredicate, contains_ord, OrdContainsPredic
 
 // combinators
 mod boolean;
+mod boxed;
 pub use self::boolean::{AndPredicate, OrPredicate, NotPredicate};
+pub use self::boxed::BoxPredicate;
 
 /// Trait for generically evaluating a type against a dynamically created
 /// predicate function.
@@ -94,7 +96,17 @@ pub trait Predicate {
         NotPredicate::new(self)
     }
 
-    /// Convenience function that returns a trait object of this `Predicate`.
+    /// Returns a `BoxPredicate` wrapper around this `Predicate` type.
+    ///
+    /// Returns a `BoxPredicate` wrapper around this `Predicate type. The
+    /// `BoxPredicate` type has a number of useful properties:
+    ///
+    ///   - It stores the inner predicate as a trait object, so the type of
+    ///     `BoxPredicate` will always be the same even if steps are added or
+    ///     removed from the predicate.
+    ///   - It is a common type, allowing it to be stored in vectors or other
+    ///     collection types.
+    ///   - It implements `Debug` and `Display`.
     ///
     /// # Examples
     ///
@@ -108,9 +120,9 @@ pub trait Predicate {
     /// assert_eq!(true, predicates[0].eval(&4));
     /// assert_eq!(false, predicates[1].eval(&4));
     /// ```
-    fn boxed(self) -> Box<Predicate<Item = Self::Item>>
-        where Self: 'static + Sized
+    fn boxed(self) -> BoxPredicate<Self::Item>
+        where Self: Sized + Send + Sync + 'static
     {
-        Box::new(self)
+        BoxPredicate::new(self)
     }
 }


### PR DESCRIPTION
Add `BoxPredicate` type that wraps a `Predicate` trait object to make it easier to store and work with predicates through a program by wrapping them as a heap-allocated trait object. Also implements `Debug` and `Display` wrappers as a convenience.