### PR TITLE
Add FnPredicate type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,15 @@
 //! assert_eq!(true, IsTheAnswer.eval(&42));
 //! let almost_the_answer = IsTheAnswer.or(predicate::contains(vec![41, 43]));
 //! assert_eq!(true, almost_the_answer.eval(&41));
+//!
+//! // Any function over a reference to the desired `Item` that returns `bool`
+//! // can easily be made into a `Predicate` using the `predicate::function`
+//! // function.
+//! let bound = 5;
+//! let predicate_fn = predicate::function(|&x| x >= bound);
+//! let between_5_and_10 = predicate_fn.and(predicate::le(10));
+//! assert_eq!(true, between_5_and_10.eval(&7));
+//! assert_eq!(false, between_5_and_10.eval(&3));
 //! ```
 
 #![deny(missing_docs, missing_debug_implementations)]

--- a/src/predicate/function.rs
+++ b/src/predicate/function.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2017, Nick Stevens <nick@bitcurry.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Definition of `Predicate` for wrapping a `Fn(&T) -> bool`
+
+use std::marker::PhantomData;
+
+use Predicate;
+
+/// Predicate that wraps a function over a reference that returns a `bool`.
+/// This type is returned by the `predicate::function` function.
+#[derive(Debug)]
+pub struct FnPredicate<F, T>
+where
+    F: Fn(&T) -> bool
+{
+    function: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<F, T> Predicate for FnPredicate<F, T>
+where
+    F: Fn(&T) -> bool,
+{
+    type Item = T;
+
+    fn eval(&self, variable: &T) -> bool {
+        (self.function)(variable)
+    }
+}
+
+/// Creates a new predicate that wraps over the given function. The returned
+/// type implements `Predicate` and therefore has all combinators available to
+/// it.
+///
+/// # Examples
+///
+/// ```
+/// use predicates::predicate::{self, Predicate};
+///
+/// struct Example {
+///     string: String,
+///     number: i32,
+/// }
+///
+/// let string_check = predicate::function(|x: &Example| x.string == "hello");
+/// let number_check = predicate::function(|x: &Example| x.number == 42);
+/// let predicate_fn = string_check.and(number_check);
+/// let good_example = Example { string: "hello".into(), number: 42 };
+/// assert_eq!(true, predicate_fn.eval(&good_example));
+/// let bad_example = Example { string: "goodbye".into(), number: 0 };
+/// assert_eq!(false, predicate_fn.eval(&bad_example));
+/// ```
+pub fn function<F, T>(function: F) -> FnPredicate<F, T>
+where
+    F: Fn(&T) -> bool,
+{
+    FnPredicate {
+        function: function,
+        _phantom: PhantomData,
+    }
+}

--- a/src/predicate/mod.rs
+++ b/src/predicate/mod.rs
@@ -13,9 +13,11 @@
 
 // primitive `Predicate` types
 mod constant;
+mod function;
 mod ord;
 mod set;
 pub use self::constant::{always, never, BooleanPredicate};
+pub use self::function::{function, FnPredicate};
 pub use self::ord::{eq, ne, lt, le, gt, ge, EqPredicate, OrdPredicate};
 pub use self::set::{contains, ContainsPredicate, contains_ord, OrdContainsPredicate,
                     contains_hashable, HashableContainsPredicate};


### PR DESCRIPTION
This adds a wrapper for functions of the form `Fn(&T) -> bool`, basically the same format as the `eval` function of `Predicate`. I think this provides a way more accessible option for evaluating the member fields of a struct than #2:

```
use predicates::predicate::{self, Predicate};

struct Example {
     string: String,
     number: i32,
}

let string_check = predicate::function(|x: &Example| x.string == "hello");
let number_check = predicate::function(|x: &Example| x.number == 42);
let predicate_fn = string_check.and(number_check);

let good_example = Example { string: "hello".into(), number: 42 };
assert_eq!(true, predicate_fn.eval(&good_example));

let bad_example = Example { string: "goodbye".into(), number: 0 };
assert_eq!(false, predicate_fn.eval(&bad_example));
```

This will probably also be useful in other ways, when it's easier to just write a closure that performs the comparison needed instead of having to build up from smaller pieces.

@varzac @azdle @posborne